### PR TITLE
Implement generate plugin

### DIFF
--- a/gptos/plugins/generate_plugin.py
+++ b/gptos/plugins/generate_plugin.py
@@ -1,27 +1,44 @@
-# gptos/plugins/ethics_plugin.py
-
 from gptos.plugins.base import GPTOSPlugin
-from gptos.system.ethics import EthicsFilter, RiskLevel
+import random
+import string
 
-class EthicsPlugin(GPTOSPlugin):
-    name = "ethics"
+class GeneratePlugin(GPTOSPlugin):
+    """Simple text and password generation."""
+    name = "generate"
 
     def register(self, context):
-        pass  # Optional: future event hook registration
+        pass
 
     def execute(self, command, context):
-        if not command.args:
-            print("Usage: evaluate ethics [your command]")
+        args = command.args
+        if not args:
+            self.print_usage()
             return
 
-        input_text = " ".join(command.args)
-        filter = EthicsFilter()
-        risk, reason = filter.evaluate(input_text)
+        sub = args[0]
+        if sub == "password":
+            length = int(args[1]) if len(args) > 1 else 12
+            chars = string.ascii_letters + string.digits
+            password = "".join(random.choice(chars) for _ in range(length))
+            print(password)
+        elif sub == "lorem":
+            count = int(args[1]) if len(args) > 1 else 1
+            words = [
+                "lorem", "ipsum", "dolor", "sit", "amet", "consectetur",
+                "adipiscing", "elit", "sed", "do", "eiusmod", "tempor"
+            ]
+            sentences = []
+            for _ in range(count):
+                n_words = random.randint(4, 10)
+                sentence = " ".join(random.choice(words) for _ in range(n_words))
+                sentences.append(sentence.capitalize() + ".")
+            print(" ".join(sentences))
+        else:
+            self.print_usage()
 
-        print(f"Risk: {risk.value.upper()} | Action: {'BLOCKED' if risk == RiskLevel.BLOCKED else 'ALLOWED'}")
-        print(f"Reason: {reason}")
+    def print_usage(self):
+        print("Usage: generate [password <len>|lorem <count>]")
 
 PLUGIN_REGISTRY = {
-    "ethics": EthicsPlugin()
+    "generate": GeneratePlugin()
 }
-


### PR DESCRIPTION
## Summary
- create an actual `generate` plugin instead of a duplicate ethics plugin
- register under `generate`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68514acf8a0883269dcb01577d62d556