### PR TITLE
Make executor run plugins asynchronously

### DIFF
--- a/gptos/ui/console.py
+++ b/gptos/ui/console.py
@@ -1,3 +1,4 @@
+import asyncio
 from gptos.core.command_core.parser import parse_command
 from gptos.core.command_core.executor import execute
 from gptos.system.context_handler import SystemContext
@@ -22,7 +23,7 @@ def main():
             break
         command = parse_command(raw_input_cmd, context)
         context.log(command)
-        execute(command, context)
+        asyncio.run(execute(command, context))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- allow plugin `execute` functions to be async or sync
- run commands via async executor in console
- update `execute_command` to async interface

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68514aaa49688326a9fc29b3fae00c48