### PR TITLE
Fix CommandLogger import collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,4 +77,5 @@ All notable changes to this project will be documented in this file.
 - Enhanced system context: Added automatic memory cleanup and optimized state management
 - Applied rate limiting and cache to /execute and /rag endpoints for better API performance
 - Updated requirements.txt: Removed unnecessary packages (altgraph, future, macholib)
+- Fixed CommandLogger name clash causing AttributeError during execution
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 🧠 Modular command interface powered by plugins and prompt-driven code generation.
 
-**Version**: `0.6.1`  **Last Updated**: 2025-06-17
+**Version**: `0.6.2`  **Last Updated**: 2025-06-17
 
 ---
 

--- a/gptos/core/command_core/executor.py
+++ b/gptos/core/command_core/executor.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 from gptos.system.plugin_loader import PLUGIN_REGISTRY
-from gptos.system.command_log import logger
+from gptos.system.command_log import logger, command_logger
 from gptos.system.ethics import ethics_guard
 from gptos.core.command_core.parser import parse_command
 
@@ -51,7 +51,7 @@ async def execute_command_async(command, context):
         logger.error(f"Error executing {command.name}: {e}")
     finally:
         duration = round(time.time() - start_time, 4)
-        logger.log(
+        command_logger.log(
             raw_input=raw_input,
             parsed=vars(command),
             result=result,

--- a/gptos/plugins/devtools_plugin.py
+++ b/gptos/plugins/devtools_plugin.py
@@ -1,6 +1,6 @@
 from gptos.plugins.base import GPTOSPlugin
 import sys
-from gptos.system.command_log import logger  # 🔁 use shared instance
+from gptos.system.command_log import command_logger  # 🔁 use shared instance
 from gptos.system.executor_wrapper import executor_fn
 
 class DevtoolsPlugin(GPTOSPlugin):
@@ -50,20 +50,20 @@ class DevtoolsPlugin(GPTOSPlugin):
             target = command.args[1]
 
             if target == "last" or target == "-1":
-                logger.replay_last(executor_fn, context)
+                command_logger.replay_last(executor_fn, context)
             else:
                 try:
                     index = int(target)
-                    logger.replay(index, executor_fn, context)
+                    command_logger.replay(index, executor_fn, context)
                 except ValueError:
                     print("Usage: dev replay <index|last|-1>")
             return
 
         elif sub == "log":
-            if not logger.entries:
+            if not command_logger.entries:
                 print("[log] No entries yet.")
             else:
-                for i, entry in enumerate(logger.entries):
+                for i, entry in enumerate(command_logger.entries):
                     print(f"[{i}] {entry.raw_input}")
             return
 

--- a/gptos/plugins/log_plugin.py
+++ b/gptos/plugins/log_plugin.py
@@ -1,7 +1,7 @@
 # gptos/plugins/log_plugin.py
 
 from gptos.plugins.base import GPTOSPlugin
-from gptos.system.command_log import logger, CommandLogEntry
+from gptos.system.command_log import command_logger, CommandLogEntry
 
 class LogPlugin(GPTOSPlugin):
     name = "log"
@@ -19,33 +19,33 @@ class LogPlugin(GPTOSPlugin):
 
         if subcommand == "recent":
             limit = int(args[1]) if len(args) > 1 and args[1].isdigit() else 10
-            entries = logger.entries[-limit:]
+            entries = command_logger.entries[-limit:]
             self.print_entries(entries)
 
         elif subcommand == "search" and len(args) > 1:
             keyword = " ".join(args[1:])
-            results = [e for e in logger.entries if keyword.lower() in e.raw_input.lower()]
+            results = [e for e in command_logger.entries if keyword.lower() in e.raw_input.lower()]
             self.print_entries(results)
 
         elif subcommand == "filter" and "--error" in args:
-            errors = [e for e in logger.entries if e.error]
+            errors = [e for e in command_logger.entries if e.error]
             self.print_entries(errors)
 
         elif subcommand == "save" and len(args) > 1:
-            logger.save_to_file(args[1])
+            command_logger.save_to_file(args[1])
 
         elif subcommand == "load" and len(args) > 1:
-            logger.load_from_file(args[1])
+            command_logger.load_from_file(args[1])
 
         elif subcommand == "replay" and len(args) > 1 and args[1].isdigit():
             index = int(args[1])
-            logger.replay(index, context["executor"], context)
+            command_logger.replay(index, context["executor"], context)
 
         elif subcommand == "replay" and len(args) > 1 and args[1] == "last":
-            logger.replay_last(context["executor"], context)
+            command_logger.replay_last(context["executor"], context)
         elif subcommand == "filter":
             filters = self.parse_filters(args[1:])
-            results = self.filter_entries(logger.entries, filters)
+            results = self.filter_entries(command_logger.entries, filters)
             self.print_entries(results)
         else:
             print("Invalid log command. Try: log recent | log search <kw> | log filter --error | log save path | log replay 2")

--- a/gptos/plugins/summarizer_plugin.py
+++ b/gptos/plugins/summarizer_plugin.py
@@ -1,5 +1,5 @@
 from gptos.plugins.base import GPTOSPlugin
-from gptos.system.command_log import logger, CommandLogEntry
+from gptos.system.command_log import command_logger, CommandLogEntry
 from collections import defaultdict
 
 class SummarizePlugin(GPTOSPlugin):
@@ -16,7 +16,7 @@ class SummarizePlugin(GPTOSPlugin):
 
         subcommand = args[0]
         if subcommand == "usage":
-            self.summarize_plugin_usage(logger.entries)
+            self.summarize_plugin_usage(command_logger.entries)
 
     def summarize_plugin_usage(self, entries: list[CommandLogEntry]):
         stats = defaultdict(lambda: {

--- a/gptos/system/command_log.py
+++ b/gptos/system/command_log.py
@@ -153,4 +153,4 @@ class CommandLogger:
         self.entries.clear()
 
 # Singleton instance
-logger = CommandLogger()
+command_logger = CommandLogger()

--- a/gptos/system/context_handler.py
+++ b/gptos/system/context_handler.py
@@ -1,6 +1,6 @@
 import os
 from gptos.system.alias_manager import AliasManager
-from gptos.system.command_log import logger
+from gptos.system.command_log import command_logger
 from gptos.system.rag_pipeline import SimpleRAGPipeline, load_default_rag_docs
 import gc
 
@@ -14,7 +14,7 @@ class SystemContext:
             "summarize.recent_count": 10,
         }
         self.alias_manager = AliasManager()
-        self.logger = logger  # Optional, in case access needed
+        self.logger = command_logger  # Optional, in case access needed
         self.rag_pipeline = SimpleRAGPipeline()
         self.rag_pipeline.add_documents([
             "GPT OS is a modular system for language interface research.",

--- a/gptos/ui/api_server.py
+++ b/gptos/ui/api_server.py
@@ -10,7 +10,7 @@ from gptos.system.command_log import logger
 import time
 import cachetools
 
-app = FastAPI(title="GPT OS API", version="0.6.1")
+app = FastAPI(title="GPT OS API", version="0.6.2")
 # === Rate Limiting Cache ===
 rate_limit_cache = cachetools.TTLCache(maxsize=1000, ttl=60)  # TTL 60초, 최대 1000개 키 저장
 
@@ -48,7 +48,7 @@ async def get_status():
         "status": "ok",
         "loaded_plugins": list(context.plugins.keys()),
         "memory_length": len(context.memory),
-        "version": "0.6.0"
+        "version": "0.6.2"
     }
 
 @app.post("/execute")
@@ -143,7 +143,7 @@ async def get_system_status():
         "status": "ok",
         "loaded_plugins": len(context.plugins),
         "memory_length": len(context.memory),
-        "version": "0.6.0"
+        "version": "0.6.2"
     }
 
 @app.get("/system/optimize")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gptos
-version = 0.6.1
+version = 0.6.2
 description = Minimal ethical terminal-based OS
 author = Wonyoung Choi
 license = MIT

--- a/tests/test_execute_command.py
+++ b/tests/test_execute_command.py
@@ -1,5 +1,6 @@
 from io import StringIO
 import sys
+import asyncio
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -37,7 +38,7 @@ def test_execute_hello_command():
 
     buf = StringIO()
     with redirect_stdout(buf):
-        executor.execute_command('hello', ctx)
+        asyncio.run(executor.execute_command('hello', ctx))
     output = buf.getvalue()
     assert 'Hello, GPT OS!' in output
 


### PR DESCRIPTION
## Summary
- avoid `logger` name collision by exposing a `command_logger` instance
- update references across the codebase
- bump version to 0.6.2
- update failing test for async executor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863327239cc83269b5ee8b557062bb6